### PR TITLE
Use stable keys for file previews

### DIFF
--- a/src/pages/VideoCompressor.tsx
+++ b/src/pages/VideoCompressor.tsx
@@ -312,7 +312,10 @@ function VideoCompressorContent() {
               <CardContent>
                 <div className="space-y-4">
                   {selectedFiles.map((file, index) => (
-                    <div key={index} className="border rounded-lg p-4">
+                    <div
+                      key={`${file.name}-${file.lastModified}`}
+                      className="border rounded-lg p-4"
+                    >
                       <div className="flex items-center justify-between mb-2">
                         <span className="font-medium">{file.name}</span>
                         <span className="text-sm text-muted-foreground">

--- a/src/pages/VideoRepair.tsx
+++ b/src/pages/VideoRepair.tsx
@@ -347,7 +347,10 @@ function VideoRepairContent() {
               <CardContent>
                 <div className="space-y-4">
                   {selectedFiles.map((file, index) => (
-                    <div key={index} className="border rounded-lg p-4">
+                    <div
+                      key={`${file.name}-${file.lastModified}`}
+                      className="border rounded-lg p-4"
+                    >
                       <div className="flex items-center justify-between mb-2">
                         <span className="font-medium">{file.name}</span>
                         <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- use `${file.name}-${file.lastModified}` as React keys when mapping selected files

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883bbd600088330a2189d79de94f8c4