### PR TITLE
Add ErrorBoundary component and wrap router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import ErrorBoundary from "@/components/ErrorBoundary";
 import { BackToTop } from "@/components/ui/back-to-top";
 import VideoCompressor from "./pages/VideoCompressor";
 import VideoRepair from "./pages/VideoRepair";
@@ -19,8 +20,9 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
+      <ErrorBoundary>
+        <BrowserRouter>
+          <Routes>
           <Route path="/" element={<VideoCompressor />} />
           <Route path="/repair" element={<VideoRepair />} />
           <Route path="/history" element={<History />} />
@@ -29,9 +31,10 @@ const App = () => (
           <Route path="/about" element={<About />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
-        </Routes>
-        <BackToTop />
-      </BrowserRouter>
+          </Routes>
+          <BackToTop />
+        </BrowserRouter>
+      </ErrorBoundary>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+
+    this.resetError = this.resetError.bind(this);
+  }
+
+  private resetError() {
+    this.setState({ hasError: false });
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Uncaught error:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background">
+          <p className="text-lg font-semibold text-foreground">Something went wrong.</p>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={this.resetError}>Try Again</Button>
+            <Button onClick={() => window.location.reload()}>Reload</Button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- create `ErrorBoundary` class component
- wrap `BrowserRouter` with `ErrorBoundary` in `App.tsx`
- handle resetting the boundary to let users retry

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot read properties of undefined in eslint rule)*

------
https://chatgpt.com/codex/tasks/task_e_6883bbd8b7808330a0046041a1ea3edb