### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -5,7 +5,9 @@ import { DayPicker } from "react-day-picker";
 import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
+  className?: string;
+};
 
 function Calendar({
   className,
@@ -52,8 +54,12 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ..._props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ..._props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: (props: React.SVGProps<SVGSVGElement>) => (
+          <ChevronLeft {...props} className="h-4 w-4" />
+        ),
+        IconRight: (props: React.SVGProps<SVGSVGElement>) => (
+          <ChevronRight {...props} className="h-4 w-4" />
+        ),
       }}
       {...props}
     />

--- a/src/components/video-compressor/ProgressTracker.tsx
+++ b/src/components/video-compressor/ProgressTracker.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -148,11 +147,7 @@ export function ProgressTracker({
           const isError = job.status === 'error';
           const isWaiting = job.status === 'waiting';
 
-          const compressionRatio = job.compressedSize 
-            ? ((job.originalSize - job.compressedSize) / job.originalSize) * 100
-            : 0;
-
-
+          // Compression ratio can be calculated when displaying stats
 
           return (
             <div key={job.id} className="space-y-3">

--- a/src/components/video-compressor/VideoCompressorSidebar.tsx
+++ b/src/components/video-compressor/VideoCompressorSidebar.tsx
@@ -1,4 +1,4 @@
-import { FaPlay, FaHistory, FaQuestionCircle, FaInfoCircle, FaCog, FaTools, FaWrench } from 'react-icons/fa';
+import { FaPlay, FaHistory, FaQuestionCircle, FaInfoCircle, FaCog, FaWrench } from 'react-icons/fa';
 import { NavLink } from "react-router-dom";
 import React from 'react';
 

--- a/src/pages/VideoRepair.tsx
+++ b/src/pages/VideoRepair.tsx
@@ -17,7 +17,6 @@ import {
   Download,
   RotateCcw,
   FileVideo,
-  Zap
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
@@ -58,7 +57,7 @@ function VideoRepairContent() {
     });
   }, [toast]);
 
-  const analyzeVideoFile = useCallback(async (file: File): Promise<RepairJob['issues']> => {
+  const analyzeVideoFile = useCallback(async (_file: File): Promise<RepairJob['issues']> => {
     // Simulate video analysis
     await new Promise(resolve => setTimeout(resolve, 500)); // Faster analysis
     


### PR DESCRIPTION
## Summary
- remove unused props from calendar icons
- clean up ProgressTracker imports and unused variable
- drop unused icon import in sidebar
- remove unused icon and parameter in VideoRepair
- accept and forward props for calendar icons

## Testing
- `npm install`
- `npx tsc -p tsconfig.app.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6883bc5b69188330b33c80f7166444cc