### PR TITLE
Fix CSV export sanitization

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -34,6 +34,8 @@ const STORAGE_KEYS = {
   APP_SETTINGS: 'clipsqueeze-settings',
 } as const;
 
+import { sanitizeForCSV } from './utils';
+
 // History Management
 export const getCompressionHistory = (): CompressionHistoryItem[] => {
   try {
@@ -76,14 +78,14 @@ export const exportHistory = (): void => {
   const csvContent = [
     ['File Name', 'Original Size (MB)', 'Compressed Size (MB)', 'Compression Ratio (%)', 'Preset', 'Date', 'Time', 'Status'],
     ...history.map(item => [
-      item.fileName,
+      sanitizeForCSV(item.fileName),
       (item.originalSize / (1024 * 1024)).toFixed(2),
       (item.compressedSize / (1024 * 1024)).toFixed(2),
       item.compressionRatio.toFixed(1),
-      item.preset,
-      item.date,
-      item.time,
-      item.status
+      sanitizeForCSV(item.preset),
+      sanitizeForCSV(item.date),
+      sanitizeForCSV(item.time),
+      sanitizeForCSV(item.status)
     ])
   ].map(row => row.join(',')).join('\n');
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,6 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const sanitizeForCSV = (value: string): string =>
+  /^[=+\-@]/.test(value) ? `'${value}` : value


### PR DESCRIPTION
## Summary
- avoid CSV injection by prefixing suspicious values with quotes
- move CSV helper to utils and import where needed

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6883bc6142648330a4da369740e229e2