### PR TITLE
feat: prevent compression from increasing file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This software is protected by copyright laws and international treaties. Unautho
 - **Smart File Limits**: Process files of any size, with automatic MP4 conversion for large non-MP4 files
 - **Multiple Presets**: Choose from optimized compression presets or customize settings
 - **Format Conversion**: Convert between different video formats (MP4, WebM, AVI, MOV, etc.)
+- **Size Safety**: Automatically keeps the original file if compression would increase size
 - **Real-time Progress**: Track compression and conversion progress in real-time
 - **Batch Processing**: Handle multiple files simultaneously
 

--- a/src/lib/videoProcessor.ts
+++ b/src/lib/videoProcessor.ts
@@ -107,14 +107,27 @@ export const compressVideo = async (
     
     // Convert to blob
     console.log('Creating output blob...');
-    const outputBlob = new Blob([data], { 
-      type: getMimeType(outputFormat) 
+    const outputBlob = new Blob([data], {
+      type: getMimeType(outputFormat)
     });
     console.log('Output blob created, size:', outputBlob.size);
-    
+
+    // Ensure compression actually reduced file size
+    if (outputBlob.size >= inputBlob.size) {
+      console.warn(
+        `Compressed file is larger than original. ` +
+        `Returning original file instead of expanded output.`
+      );
+      onProgress?.({
+        progress: 100,
+        message: 'Compression skipped: output larger than original file.'
+      });
+      return inputBlob;
+    }
+
     onProgress?.({ progress: 100, message: 'Compression successful!' });
     console.log('Compression completed successfully!');
-    
+
     return outputBlob;
   } catch (error) {
     console.error('Video compression failed:', error);


### PR DESCRIPTION
## Summary
- ensure compression never returns a larger file than the original
- document that larger outputs fall back to the original file

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: Unsupported platform for @rollup/rollup-win32-x64-msvc)
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa63a617988330997be6b30ccf8d64